### PR TITLE
Resolving CVE-2018-1000544

### DIFF
--- a/scorm.gemspec
+++ b/scorm.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.executables        = ['scorm']
   s.default_executable = 'scorm'
 
-  s.add_dependency('rubyzip',  '~> 0.9.4')
+  s.add_dependency('rubyzip',  '>= 1.2.2')
 end


### PR DESCRIPTION
Resolving vulnerability for SCORM dependency: rubyzip